### PR TITLE
Add cache-control headers

### DIFF
--- a/src/a11ygator.js
+++ b/src/a11ygator.js
@@ -60,7 +60,13 @@ exports.report = async (req, res) => {
     try {
         const html = await htmlReporter.results(results);
 
-        return res.send(html);
+        return res
+            .set({
+                'Expires': 'Mon, 26 Jul 1997 05:00:00 GMT',
+                'Last-Modified': (new Date()).toGMTString(),
+                'Cache-Control': 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0',
+            })
+            .send(html);
     } catch (err) {
         console.error('Failed to generate report', err);
 

--- a/src/screenshots/local.js
+++ b/src/screenshots/local.js
@@ -53,7 +53,7 @@ class LocalAdapter extends BaseAdapter {
      * @inheritdoc
      */
     getMiddleware() {
-        return express.static(this.options.path);
+        return express.static(this.options.path, { immutable: true, maxAge: '1y' });
     }
 };
 


### PR DESCRIPTION
This PR adds `Cache-Control`, `Expires` and `Last-Modified` headers to the responses that should not be cached by proxies, such as CloudFront.