### PR TITLE
Manage scheduled reports

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -54,6 +54,15 @@ exports.builder = yargs
         }),
         [stackOutputsMiddleware],
       )
+      .command(
+        'manage-scheduled',
+        'Manage scheduled reports',
+        {},
+        (argv) => require('./reports.js').manageScheduled({
+          apiUrl: argv['api-url'],
+        }),
+        [stackOutputsMiddleware],
+      )
       .demandCommand(),
   )
   .command(

--- a/cli/index.js
+++ b/cli/index.js
@@ -21,7 +21,7 @@ const stackOutputsMiddleware = async (argv) => {
 
   const CloudFormation = new AWS.CloudFormation({ apiVersion: '2010-05-15' });
 
-  spinner.prefixText = 'Getting Stack outputs...';
+  spinner.prefixText = `Getting Stack outputs for "${argv['stack-name']}"...`;
   spinner.start();
   const { Stacks } = await CloudFormation.describeStacks({ StackName: argv['stack-name'] }).promise();
   const outputs = Stacks[0].Outputs.reduce(

--- a/cli/reports.js
+++ b/cli/reports.js
@@ -180,7 +180,42 @@ exports.manageScheduled = async ({ apiUrl }) => {
       value: report,
     })),
   });
-  console.log('user chose', selected); // TODO: delete
+
+  for (const report of selected) {
+    await this.delete({ apiUrl, id: report.id });
+  }
+
+  return true;
+};
+
+/**
+ * Delete report.
+ *
+ * @param {{ apiUrl: URL, id: string }} argv Command arguments.
+ * @returns {Promise<boolean>}
+ */
+exports.delete = async ({ apiUrl, id }) => {
+  const scheduleUrl = new URL(`reports/${id}`, apiUrl);
+  const credentials = await loadCredentials();
+
+  spinner.prefixText = `Deleting report ${id}...`;
+  spinner.start();
+  const response = await request(
+    {
+      service: 'execute-api',
+      region: 'eu-west-1',
+      method: 'DELETE',
+      protocol: scheduleUrl.protocol,
+      host: scheduleUrl.host,
+      path: scheduleUrl.pathname,
+    },
+    credentials
+  );
+  if (response.statusCode >= 400) {
+    spinner.fail('fail');
+    throw new Error(`Got error ${response.statusCode} ${response.statusMessage}`);
+  }
+  spinner.succeed('done');
 
   return true;
 };

--- a/cli/reports.js
+++ b/cli/reports.js
@@ -138,6 +138,12 @@ exports.schedule = async ({ apiUrl }) => {
   return true;
 };
 
+/**
+ * List and optionally delete scheduled reports.
+ *
+ * @param {{ apiUrl: URL }} argv Command arguments.
+ * @returns {Promise<boolean>}
+ */
 exports.manageScheduled = async ({ apiUrl }) => {
   const scheduleUrl = new URL('schedules', apiUrl);
   const credentials = await loadCredentials();

--- a/cli/reports.js
+++ b/cli/reports.js
@@ -169,6 +169,12 @@ exports.manageScheduled = async ({ apiUrl }) => {
   }
   const reports = JSON.parse(response.body.toString());
 
+  if (!reports || !reports.length) {
+    spinner.info('no planned reports');
+
+    return true;
+  }
+
   spinner.succeed('done');
 
   const { selected } = await prompts({

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,6 +38,11 @@ Manage reports.
 Schedules a report for future generation. The CLI will interactively ask the URL
 to analyze and the time at which generate the report.
 
+#### `reports manage-scheduled`
+
+List reports scheduled to be generated in the future. The CLI will let the user
+interactively choose one or more schedules to abort.
+
 ### Twitter management
 
 Manage Twitter bot.

--- a/lambda/report-delete/index.js
+++ b/lambda/report-delete/index.js
@@ -1,0 +1,141 @@
+const AWS = require('aws-sdk');
+
+const REPORTS_TABLE = process.env.REPORTS_TABLE;
+const S3_BUCKET = process.env.S3_BUCKET;
+const SCHEDULED_REPORTS_STATE_MACHINE = process.env.SCHEDULED_REPORTS_STATE_MACHINE;
+
+const DDB = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' });
+const S3 = new AWS.S3({ apiVersion: '2006-03-01' });
+const StepFunctions = new AWS.StepFunctions({ apiVersion: '2016-11-23' });
+
+/**
+ * Get info stored in DynamoDB for a report.
+ *
+ * @param {string} id Report ID.
+ * @returns {Promise<{ Source: string, CompletedTimestamp?: number, ReportError?: any, ScheduledTimestamp?: number } | null>}
+ */
+const getInfo = async (id) => {
+  console.time('Reading report info from DynamoDB');
+  const info = await DDB.get({
+    TableName: REPORTS_TABLE,
+    Key: { Id: id },
+  }).promise();
+  console.timeEnd('Reading report info from DynamoDB');
+  if (!info.Item) {
+    return null;
+  }
+
+  return info.Item;
+};
+
+/**
+ * Delete all report data from S3 (JSON and screenshots).
+ *
+ * @param {string} id Report ID.
+ * @returns {Promise<void>}
+ */
+const deleteReportData = async (id) => {
+  const reportKey = `reports/${id}.json`;
+  const screenshotKey = `screenshots/${id}.png`;
+  const fullPageScreenshotKey = `screenshots/${id}-full.png`;
+
+  console.time('Deleting report data from S3');
+  await Promise.all([
+    S3.deleteObject({
+      Bucket: S3_BUCKET,
+      Key: reportKey,
+    }).promise(),
+    S3.putObject({
+      Bucket: S3_BUCKET,
+      Key: screenshotKey,
+    }).promise(),
+    S3.putObject({
+      Bucket: S3_BUCKET,
+      Key: fullPageScreenshotKey,
+    }).promise(),
+  ]);
+  console.timeEnd('Deleting report data from S3');
+};
+
+/**
+ * Stop step function execute that would eventually enqueue report generation.
+ *
+ * @param {string} id Report ID.
+ * @returns {Promise<void>}
+ */
+const stopStepFunction = async (id) => {
+  console.time('Listing step function executions');
+  const list = await StepFunctions.listExecutions({
+    stateMachineArn: SCHEDULED_REPORTS_STATE_MACHINE,
+    statusFilter: 'RUNNING',
+  }).promise();
+  console.timeEnd('Listing step function executions');
+
+  const execution = list.executions.find((exec) => exec.name === id);
+  if (!execution) {
+    console.error(`Could not find an execution with name "${id}".`);
+
+    return;
+  }
+
+  console.time('Stopping step function execution');
+  await StepFunctions.stopExecution({
+    executionArn: execution.executionArn,
+    cause: `Aborted on ${new Date().toUTCString()}.`,
+  }).promise();
+  console.timeEnd('Stopping step function execution');
+};
+
+/**
+ * Delete report info stored on DynamoDB.
+ *
+ * @param {string} id Report ID.
+ * @returns {Promise<void>}
+ */
+const deleteInfo = async (id) => {
+  console.time('Deleting report info from DynamoDB');
+  await DDB.delete({
+    TableName: REPORTS_TABLE,
+    Key: { Id: id },
+  }).promise();
+  console.timeEnd('Deleting report info from DynamoDB');
+};
+
+/**
+ * Start state machine with report generation requests received via API Gateway.
+ *
+ * @param {{ pathParameters: { id: string } }} event API event.
+ * @returns {Promise<{ statusCode: number, headers?: { [x: string]: string }, body?: string }>}
+ */
+exports.handler = async ({ pathParameters }) => {
+  const { id } = pathParameters;
+
+  const info = await getInfo(id);
+  if (!info) {
+    // Already deleted.
+    return { statusCode: 204 };
+  }
+
+  if (info.CompletedTimestamp) {
+    // Report was uploaded.
+    await deleteReportData(id);
+  } else if (info.Source === 'schedule' && info.ScheduledTimestamp > Date.now()) {
+    // Abort scheduled report.
+    await stopStepFunction(id);
+  } else if (!info.ReportError) {
+    // Report is neither completed nor scheduled, thus is being generated right now.
+    // Refuse to delete a report being generated now to avoid creating orphaned files on S3.
+    const message = `Refusing to delete a report that is being generated right now: ${id}`;
+
+    return {
+      statusCode: 423,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message }),
+    };
+  }
+
+  // Delete report info from DynamoDB.
+  await deleteInfo(id);
+
+  return { statusCode: 204 };
+};

--- a/lambda/report-delete/index.js
+++ b/lambda/report-delete/index.js
@@ -49,7 +49,7 @@ const deleteReportData = async (id) => {
       Bucket: S3_BUCKET,
       Key: screenshotKey,
     }).promise(),
-    S3.deleteObject({å
+    S3.deleteObject({
       Bucket: S3_BUCKET,
       Key: fullPageScreenshotKey,
     }).promise(),
@@ -58,7 +58,7 @@ const deleteReportData = async (id) => {
 };
 
 /**
- * Stop step function execute that would eventually enqueue report generation.
+ * Stop step function execution that would eventually enqueue report generation.
  *
  * @param {string} id Report ID.
  * @returns {Promise<void>}

--- a/lambda/report-delete/index.js
+++ b/lambda/report-delete/index.js
@@ -45,11 +45,11 @@ const deleteReportData = async (id) => {
       Bucket: S3_BUCKET,
       Key: reportKey,
     }).promise(),
-    S3.putObject({
+    S3.deleteObject({
       Bucket: S3_BUCKET,
       Key: screenshotKey,
     }).promise(),
-    S3.putObject({
+    S3.deleteObject({å
       Bucket: S3_BUCKET,
       Key: fullPageScreenshotKey,
     }).promise(),

--- a/lambda/report-schedules-list/index.js
+++ b/lambda/report-schedules-list/index.js
@@ -1,0 +1,32 @@
+const AWS = require('aws-sdk');
+
+const REPORTS_TABLE = process.env.REPORTS_TABLE;
+
+const DDB = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' });
+
+/**
+ * Start state machine with report generation requests received via API Gateway.
+ *
+ * @param {{ queryStringParameters?: { filter?: 'future' } }} event API event.
+ * @returns {Promise<{ headers: {} }>}
+ */
+exports.handler = async (event) => {
+  const allSchedules = await DDB.query({
+    TableName: REPORTS_TABLE,
+    IndexName: 'Schedule',
+    KeyConditionExpression: 'Source = :source AND ScheduledTimestamp > :now',
+    ExpressionAttributeValues: {
+      ':source': 'schedule',
+      ':now': Date.now(),
+    },
+  }).promise();
+
+  const items = allSchedules.Items.map((item) => ({ id: item.Id, url: item.Url, schedule: new Date(ScheduledTimestamp), mention: item.Mention || null }));
+
+  return {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(items),
+  };
+};

--- a/lambda/report-schedules-list/index.js
+++ b/lambda/report-schedules-list/index.js
@@ -5,7 +5,7 @@ const REPORTS_TABLE = process.env.REPORTS_TABLE;
 const DDB = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' });
 
 /**
- * Start state machine with report generation requests received via API Gateway.
+ * List upcoming scheduled reports.
  *
  * @param {{ queryStringParameters?: { filter?: 'future' } }} event API event.
  * @returns {Promise<{ statusCode: number, headers?: { [x: string]: string }, body?: string }>}

--- a/templates/root.yml
+++ b/templates/root.yml
@@ -172,6 +172,14 @@ Resources:
               KeyType: 'HASH'
           Projection:
             ProjectionType: 'KEYS_ONLY'
+        - IndexName: 'Schedule'
+          KeySchema:
+            - AttributeName: 'Source'
+              KeyType: 'HASH'
+            - ScheduledTimestamp: 'ScheduledTimestamp'
+              KeyType: 'RANGE'
+          Projection:
+            ProjectionType: 'ALL'
       BillingMode: 'PAY_PER_REQUEST'
 
   ##########################################
@@ -503,6 +511,51 @@ Resources:
       Principal: 'apigateway.amazonaws.com'
       SourceArn: !Sub 'arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${Api}/*/POST/schedules'
 
+  #######################################################
+  ### Function to schedule report generation requests ###
+  #######################################################
+  ReportScheduleListRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: 'Allow'
+            Principal:
+              Service: 'lambda.amazonaws.com'
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      Policies:
+        - PolicyName: 'ListScheduledReport'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: 'QueryBySource'
+                Effect: 'Allow'
+                Action: 'dynamodb:Query'
+                Resource: !Sub '${ReportsTable.Arn}/index/Schedule'
+  ReportScheduleListFunction:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Layers:
+        - !Ref 'UuidLayer'
+      Code: '../lambda/report-schedules-list'
+      Description: !Sub 'List scheduled reports for ${AWS::StackName}.'
+      Environment:
+        Variables:
+          REPORTS_TABLE: !Ref 'ReportsTable'
+      Handler: 'index.handler'
+      Role: !GetAtt 'ReportScheduleListRole.Arn'
+      Runtime: 'nodejs10.x'
+  ReportScheduleListFunctionPermission:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      FunctionName: !GetAtt 'ReportScheduleListFunction.Arn'
+      Action: 'lambda:InvokeFunction'
+      Principal: 'apigateway.amazonaws.com'
+      SourceArn: !Sub 'arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${Api}/*/GET/schedules'
+
   ###########################################################
   ### Function to handle Twitter Challenge Response Check ###
   ###########################################################
@@ -762,6 +815,22 @@ Resources:
                 httpMethod: 'POST'
                 uri: !Sub 'arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ReportViewFunction.Arn}/invocations'
           /schedules:
+            get:
+              description: 'List scheduled reports.'
+              security:
+                - sigv4: []
+              x-amazon-apigateway-request-validator: 'all'
+              responses:
+                '200':
+                  description: 'List of scheduled reports.'
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/ReportScheduleListResponse'
+              x-amazon-apigateway-integration:
+                type: 'aws_proxy'
+                httpMethod: 'POST'
+                uri: !Sub 'arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ReportScheduleListFunction.Arn}/invocations'
             post:
               description: 'Schedule report generation.'
               security:

--- a/templates/root.yml
+++ b/templates/root.yml
@@ -146,6 +146,10 @@ Resources:
           AttributeType: 'S'
         - AttributeName: 'TweetId'
           AttributeType: 'S'
+        - AttributeName: 'Source'
+          AttributeType: 'S'
+        - AttributeName: 'ScheduledTimestamp'
+          AttributeType: 'N'
       KeySchema:
         - AttributeName: 'Id'
           KeyType: 'HASH'
@@ -176,7 +180,7 @@ Resources:
           KeySchema:
             - AttributeName: 'Source'
               KeyType: 'HASH'
-            - ScheduledTimestamp: 'ScheduledTimestamp'
+            - AttributeName: 'ScheduledTimestamp'
               KeyType: 'RANGE'
           Projection:
             ProjectionType: 'ALL'
@@ -538,8 +542,6 @@ Resources:
   ReportScheduleListFunction:
     Type: 'AWS::Lambda::Function'
     Properties:
-      Layers:
-        - !Ref 'UuidLayer'
       Code: '../lambda/report-schedules-list'
       Description: !Sub 'List scheduled reports for ${AWS::StackName}.'
       Environment:

--- a/templates/root.yml
+++ b/templates/root.yml
@@ -465,6 +465,65 @@ Resources:
       Principal: 'apigateway.amazonaws.com'
       SourceArn: !Sub 'arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${Api}/*/GET/reports/*'
 
+  ############################################
+  ### Function to delete generated reports ###
+  ############################################
+  ReportDeleteRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: 'Allow'
+            Principal:
+              Service: 'lambda.amazonaws.com'
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      Policies:
+        - PolicyName: 'Reports'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: 'GetAndDeleteInfo'
+                Effect: 'Allow'
+                Action:
+                  - 'dynamodb:GetItem'
+                  - 'dynamodb:DeleteItem'
+                Resource: !GetAtt 'ReportsTable.Arn'
+              - Sid: 'DeleteReportData'
+                Effect: 'Allow'
+                Action: 's3:DeleteObject'
+                Resource: !Sub '${ReportsBucket.Arn}/reports/*'
+              - Sid: 'ListScheduledRequests'
+                Effect: 'Allow'
+                Action: 'states:ListExecutions'
+                Resource: !Ref 'ScheduledReportsStateMachine'
+              - Sid: 'AbortScheduledRequest'
+                Effect: 'Allow'
+                Action: 'states:StopExecution'
+                Resource: '*'
+  ReportDeleteFunction:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Code: '../lambda/report-delete'
+      Description: !Sub 'Handle report delete requests for ${AWS::StackName}.'
+      Environment:
+        Variables:
+          REPORTS_TABLE: !Ref 'ReportsTable'
+          S3_BUCKET: !Ref 'ReportsBucket'
+          SCHEDULED_REPORTS_STATE_MACHINE: !Ref 'ScheduledReportsStateMachine'
+      Handler: 'index.handler'
+      Role: !GetAtt 'ReportDeleteRole.Arn'
+      Runtime: 'nodejs10.x'
+  ReportDeleteFunctionPermission:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      FunctionName: !GetAtt 'ReportDeleteFunction.Arn'
+      Action: 'lambda:InvokeFunction'
+      Principal: 'apigateway.amazonaws.com'
+      SourceArn: !Sub 'arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${Api}/*/DELETE/reports/*'
+
   #######################################################
   ### Function to schedule report generation requests ###
   #######################################################
@@ -816,6 +875,27 @@ Resources:
                 type: 'aws_proxy'
                 httpMethod: 'POST'
                 uri: !Sub 'arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ReportViewFunction.Arn}/invocations'
+            delete:
+              description: 'Delete report.'
+              security:
+                - sigv4: []
+              x-amazon-apigateway-request-validator: 'all'
+              parameters:
+                - in: 'path'
+                  name: 'id'
+                  schema:
+                    type: 'string'
+                  description: 'Report ID.'
+                  required: true
+              responses:
+                '204':
+                  description: 'Report deleted.'
+                '423':
+                  description: 'Report could not be deleted because it is being generated right now.'
+              x-amazon-apigateway-integration:
+                type: 'aws_proxy'
+                httpMethod: 'POST'
+                uri: !Sub 'arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ReportDeleteFunction.Arn}/invocations'
           /schedules:
             get:
               description: 'List scheduled reports.'


### PR DESCRIPTION
This PR resolves #23 and introduces both an endpoint to list reports scheduled to be generated in the future, and a CLI to manage upcoming scheduled reports.

![a11ygator-cli-manage](https://user-images.githubusercontent.com/7108146/60519463-e2515100-9ce3-11e9-83c3-eac58ca76714.gif)